### PR TITLE
Replace native config with meshkit config manager

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -20,9 +20,8 @@ package adapter
 import (
 	"context"
 
-	"github.com/layer5io/meshery-adapter-library/config"
+	meshkitCfg "github.com/layer5io/meshkit/config"
 	"github.com/layer5io/meshkit/logger"
-
 	mesherykube "github.com/layer5io/meshkit/utils/kubernetes"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -47,10 +46,10 @@ type Handler interface {
 // Adapter contains all handlers, channels, clients, and other parameters for an adapter.
 // Use type embedding in a specific adapter to extend it.
 type Adapter struct {
-	Config config.Handler
+	Config meshkitCfg.Handler
 	Log    logger.Handler
 
-	KubeconfigHandler config.Handler
+	KubeconfigHandler meshkitCfg.Handler
 	Channel           *chan interface{}
 
 	KubeClient        *kubernetes.Clientset


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**

This PR fixes #32 

This PR replaces meshery-adapter-library config implementation with meshkit's config implementation.

**Notes for Reviewers**


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
