### PR TITLE
error handling to avoid panic in component generation

### DIFF
--- a/adapter/oam.go
+++ b/adapter/oam.go
@@ -180,6 +180,9 @@ func RegisterWorkLoadsDynamically(runtime, host string, dc *DynamicComponentsCon
 	if err != nil {
 		return ErrGenerateComponents(err)
 	}
+	if comp == nil {
+		return ErrGenerateComponents(errors.New("failed to generate components"))
+	}
 	for i, def := range comp.Definitions {
 		var ord OAMRegistrantData
 		ord.OAMRefSchema = comp.Schemas[i]


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

In runtime component generation, there is a case where nil deference panic can take place. An extra step to avoid it.

**Notes for Reviewers**


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
