### PR TITLE
Improve clarity of error messages in ErrCreatingComponents

### DIFF
--- a/adapter/error.go
+++ b/adapter/error.go
@@ -142,7 +142,7 @@ func ErrGenerateComponents(err error) error {
 
 // ErrCreatingComponents
 func ErrCreatingComponents(err error) error {
-	return errors.New(ErrCreatingComponentsCode, errors.Alert, []string{"error creating components"}, []string{err.Error()}, []string{"Invalid Path or version passed in static configuration", "URL passed maybe incorrect", "Version passed maybe incorrect"}, []string{"Make sure to pass correct configuration", "Make sure the URL passed in the configuration is correct", "Make sure a valid version is passed in configuration"})
+	return errors.New(ErrCreatingComponentsCode, errors.Alert, []string{"error creating components"}, []string{err.Error()}, []string{"Invalid Path or version passed in static configuration", " URL passed maybe incorrect", " Version passed maybe incorrect"}, []string{"Make sure to pass correct configuration", " Make sure the URL passed in the configuration is correct", " Make sure a valid version is passed in configuration"})
 }
 
 func ErrRegisterComponents(err error) error {


### PR DESCRIPTION
so the current error logging contains `configuration.URL`, `incorrect.Version`, `configuration.Make` and `correct.Make` looking like some sort of an object like this:
![image](https://github.com/user-attachments/assets/5b3cf023-a913-4bc7-9232-f19b6bd0aba4)

so I thought about adding some spaces in the error message for clarity to look like this:
![image](https://github.com/user-attachments/assets/5fae9b60-508c-4f1c-996f-45600797a11d)

If this is a desired behavior let me know so I can update other errors in the same way, If not, this pr should be closed